### PR TITLE
Double the Max Perm Size.

### DIFF
--- a/ansible/group_vars/weblogic-admin.yml
+++ b/ansible/group_vars/weblogic-admin.yml
@@ -15,7 +15,7 @@ admin_templates:
 # Defaults
 domain_name: NDelius
 server_name: AdminServer
-server_params: -Xms2048m -Xmx2048m -XX:MaxPermSize=256m
+server_params: -Xms2048m -Xmx2048m -XX:MaxPermSize=512m
 server_username: weblogic
 server_password: webl0gic
 server_listen_address: 0.0.0.0


### PR DESCRIPTION
This doubles the max perm size as we are seeing out of max perm size
errors in production.

Caused by: java.lang.OutOfMemoryError: PermGen space