### PR TITLE
Amended syntax to resolve failure of ami publish

### DIFF
--- a/oracle-client.json
+++ b/oracle-client.json
@@ -41,7 +41,7 @@
       "instance_type": "t2.medium",
       "ami_regions": ["eu-west-2"],
       "ssh_username": "centos",
-      "ami_users": "{{user `ami_users`}}",
+      "ami_users": ["{{user `ami_users`}}"],
       "ami_name": "HMPPS Delius-Core Oracle Client {{user `branch_name`}} {{timestamp}}",
       "tags": {
         "OS_Version": "CentOS Linux 7",

--- a/oracle11g.json
+++ b/oracle11g.json
@@ -42,7 +42,7 @@
       "instance_type": "t2.medium",
       "ami_regions": ["eu-west-2"],
       "ssh_username": "centos",
-      "ami_users": "{{user `ami_users`}}",
+      "ami_users": ["{{user `ami_users`}}"],
       "ami_name": "HMPPS OracleDB 11g {{user `branch_name`}} {{timestamp}}",
       "tags": {
         "OS_Version": "CentOS Linux 7",

--- a/oracle18c.json
+++ b/oracle18c.json
@@ -41,7 +41,7 @@
       "instance_type": "t2.medium",
       "ami_regions": ["eu-west-2"],
       "ssh_username": "centos",
-      "ami_users": "{{user `ami_users`}}",
+      "ami_users": ["{{user `ami_users`}}"],
       "ami_name": "HMPPS OracleDB 18c {{user `branch_name`}} {{timestamp}}",
       "tags": {
         "OS_Version": "CentOS Linux 7",

--- a/oracle19c.json
+++ b/oracle19c.json
@@ -40,7 +40,7 @@
       "instance_type": "t2.medium",
       "ami_regions": ["eu-west-2"],
       "ssh_username": "centos",
-      "ami_users": "{{user `ami_users`}}",
+      "ami_users": ["{{user `ami_users`}}"],
       "ami_name": "HMPPS OracleDB 19c {{user `branch_name`}} {{timestamp}}",
       "tags": {
         "OS_Version": "CentOS Linux 7",

--- a/oracledb.json
+++ b/oracledb.json
@@ -41,7 +41,7 @@
       "instance_type": "t2.medium",
       "ami_regions": ["eu-west-2"],
       "ssh_username": "centos",
-      "ami_users": "{{user `ami_users`}}",
+      "ami_users": ["{{user `ami_users`}}"],
       "ami_name": "HMPPS Delius-Core OracleDB {{user `branch_name`}} {{timestamp}}",
       "tags": {
         "OS_Version": "CentOS Linux 7",

--- a/weblogic-admin.json
+++ b/weblogic-admin.json
@@ -44,7 +44,7 @@
       "instance_type": "t2.medium",
       "ami_regions": ["eu-west-2"],
       "ssh_username": "centos",
-      "ami_users": "{{user `ami_users`}}",
+      "ami_users": ["{{user `ami_users`}}"],
       "ami_name": "HMPPS Delius-Core Weblogic-Admin {{user `branch_name`}} {{timestamp}}",
       "tags": {
         "OS_Version": "CentOS Linux 7",

--- a/weblogic.json
+++ b/weblogic.json
@@ -41,7 +41,7 @@
       "instance_type": "t3.large",
       "ami_regions": ["eu-west-2"],
       "ssh_username": "centos",
-      "ami_users": "{{user `ami_users`}}",
+      "ami_users": ["{{user `ami_users`}}"],
       "ami_name": "HMPPS Delius-Core Weblogic {{user `branch_name`}} {{timestamp}}",
       "tags": {
         "OS_Version": "CentOS Linux 7",


### PR DESCRIPTION
Changed the SSM param to enable correct attribute type of list.
https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/codebuild/ami_users/description?region=eu-west-2&tab=Table#list_parameter_filters=Name:Contains:%2Fcodebuild%2Fami_users